### PR TITLE
gnupg is needed on Ubuntu to add Jenkins apt repository key

### DIFF
--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -4,6 +4,7 @@
     name:
       - curl
       - apt-transport-https
+      - gnupg
     state: present
 
 - name: Add Jenkins apt repository key.


### PR DESCRIPTION
Hi,

testing on Ubuntu 18.04, I realized that `gnupg` is needed for ansible's `apt_key` module to work as expected. 

Nice role by the way!